### PR TITLE
Use builtin random-uuid function for cljs. Check exact UUID length in test

### DIFF
--- a/src/brute/entity.cljc
+++ b/src/brute/entity.cljc
@@ -13,11 +13,7 @@
   "create a UUID"
   []
   #?(:clj  (java.util.UUID/randomUUID)
-     :cljs (let [template "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
-                 f #(let [r (Math/floor (* (rand) 16))
-                          v (if (= % \x) r (bit-or (bit-and r 0x3) 0x8))]
-                     (.toString v 16))]
-             (.replace template (js/RegExp. "[xy]" "g") f))))
+     :cljs (random-uuid)))
 
 (defn create-entity
   "Create the entity and return it. Entities are just UUIDs"

--- a/test/brute/entity_test.cljc
+++ b/test/brute/entity_test.cljc
@@ -41,10 +41,10 @@
 (deftest entity-unique-uuid
   (let [uuid (create-entity)]
     (is uuid)
-    #?(:clj  (do (is (> (-> uuid .toString .length) 0))
+    #?(:clj  (do (is (= (-> uuid .toString .length) 36))
                  (is (= (class uuid) UUID)))
-       :cljs (do (is (> (.-length uuid) 0))
-                 (is (= (type uuid) (type "")))))
+       :cljs (do (is (= (-> uuid .toString .-length) 36))
+                 (is (= (type uuid) UUID))))
     (is (not= (create-entity) uuid))))
 
 ;; Creating and adding an entity results in it being added to the global list


### PR DESCRIPTION
Wasn't sure if there was a reason you were using your own implementation (likely the one in cljs.core didn't exist when you added yours). Here's where it's implemented if you're curious: https://github.com/clojure/clojurescript/blob/628d957f3ecabf8d26d57665abdef3dea765151e/src/main/cljs/cljs/core.cljs#L9866.

Changed the length test to be more exact - a generated UUID should always be 36 characters.
